### PR TITLE
Fix slugify to trim trailing hyphen

### DIFF
--- a/lib/core/utils/slug.dart
+++ b/lib/core/utils/slug.dart
@@ -1,0 +1,19 @@
+String slugify(String input) {
+  final lower = input.trim().toLowerCase();
+  var replaced = lower
+      .replaceAll(RegExp(r"[áàâãä]"), "a")
+      .replaceAll(RegExp(r"[éèêë]"), "e")
+      .replaceAll(RegExp(r"[íìîï]"), "i")
+      .replaceAll(RegExp(r"[óòôõö]"), "o")
+      .replaceAll(RegExp(r"[úùûü]"), "u")
+      .replaceAll(RegExp(r"[ç]"), "c")
+      .replaceAll(RegExp(r"[^a-z0-9]+"), "-")
+      .replaceAll(RegExp(r"-+"), "-");
+  if (replaced.startsWith('-')) {
+    replaced = replaced.substring(1);
+  }
+  if (replaced.endsWith('-')) {
+    replaced = replaced.substring(0, replaced.length - 1);
+  }
+  return replaced;
+}

--- a/lib/features/profile/profile_page.dart
+++ b/lib/features/profile/profile_page.dart
@@ -3,6 +3,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import '../../core/services/auth_service.dart';
 import '../../core/services/firestore_refs.dart';
+import '../../core/utils/slug.dart';
 
 class ProfilePage extends StatefulWidget {
   const ProfilePage({super.key});
@@ -31,19 +32,6 @@ class _ProfilePageState extends State<ProfilePage> {
     return usersCol().doc(uid).get();
   }
 
-  String _slug(String input) {
-    final lower = input.trim().toLowerCase();
-    final replaced = lower
-        .replaceAll(RegExp(r"[áàâãä]"), "a")
-        .replaceAll(RegExp(r"[éèêë]"), "e")
-        .replaceAll(RegExp(r"[íìîï]"), "i")
-        .replaceAll(RegExp(r"[óòôõö]"), "o")
-        .replaceAll(RegExp(r"[úùûü]"), "u")
-        .replaceAll(RegExp(r"[ç]"), "c")
-        .replaceAll(RegExp(r"[^a-z0-9]+"), "-")
-        .replaceAll(RegExp(r"-+"), "-");
-    return replaced.startsWith("-") ? replaced.substring(1) : replaced;
-  }
 
   Future<void> _saveProfile() async {
     try {
@@ -65,9 +53,9 @@ class _ProfilePageState extends State<ProfilePage> {
         if (countryName.isNotEmpty) 'countryName': countryName,
         if (stateName.isNotEmpty) 'stateName': stateName,
         if (cityName.isNotEmpty) 'cityName': cityName,
-        if (countryName.isNotEmpty) 'countryKey': _slug(countryName),
-        if (stateName.isNotEmpty) 'stateKey': _slug(stateName),
-        if (cityName.isNotEmpty) 'cityKey': _slug(cityName),
+        if (countryName.isNotEmpty) 'countryKey': slugify(countryName),
+        if (stateName.isNotEmpty) 'stateKey': slugify(stateName),
+        if (cityName.isNotEmpty) 'cityKey': slugify(cityName),
       };
 
       await usersCol().doc(uid).set(updates, SetOptions(merge: true));

--- a/test/slug_test.dart
+++ b/test/slug_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:colheita_rua/core/utils/slug.dart';
+
+void main() {
+  group('slugify', () {
+    test('removes leading and trailing hyphens', () {
+      expect(slugify(' São Paulo! '), 'sao-paulo');
+      expect(slugify('Azul!'), 'azul');
+    });
+
+    test('handles multiple separators', () {
+      expect(slugify('Rio---de Janeiro'), 'rio-de-janeiro');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- extract slugify utility for location keys and remove trailing hyphens
- use slugify in profile page
- add tests for slugify behavior

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68a4dc0422288331ad9ecc1fc7f1cf85